### PR TITLE
Fix Vale Totems miniquest being marked as hidden

### DIFF
--- a/public/data/quest_data.json
+++ b/public/data/quest_data.json
@@ -1240,9 +1240,9 @@
   "5194": {
     "name": "Vale Totems",
     "difficulty": "Novice",
-    "points": "0",
+    "points": 0,
     "member": true,
-    "hidden": true
+    "miniquest": true
   },
   "7033": {
     "name": "Tutorial Island",

--- a/resources/js/quests/scraper.js
+++ b/resources/js/quests/scraper.js
@@ -62,6 +62,9 @@ async function run() {
       continue;
     }
 
+    // Quests like Vale Totems explicitly calls out its a miniquest to differentiate with the minigame of the same name
+    quest.name = quest.name.replace(" (miniquest)", "");
+
     if (!questNameToIdMap.has(quest.name)) {
       console.error(`quest mapping is missing quest ${quest.name} from the wiki`);
       continue;


### PR DESCRIPTION
The wiki lists Vale Totem with a suffix in the table which differs from its cache name. This removes the suffix to let the mapping work as intended.

(Even the wiki sync is currently getting this wrong currently)