### PR TITLE
Fix collection log

### DIFF
--- a/app/Http/Controllers/GroupMemberController.php
+++ b/app/Http/Controllers/GroupMemberController.php
@@ -157,7 +157,7 @@ class GroupMemberController extends Controller
             'quiver' => 'nullable|array',
             'deposited' => 'nullable|array',
             'diary_vars' => 'nullable|array',
-            'collection_log' => 'nullable|array',
+            'collection_log_v2' => 'nullable|array',
             'interacting' => 'nullable',
         ]);
 
@@ -188,7 +188,7 @@ class GroupMemberController extends Controller
         Validators::validateMemberPropLength('deposited', $validated['deposited'] ?? null, 0, 200);
         Validators::validateMemberPropLength('diary_vars', $validated['diary_vars'] ?? null, 0, 62);
 
-        $collectionLogData = $validated['collection_log'] ?? null;
+        $collectionLogData = $validated['collection_log_v2'] ?? null;
 
         DB::transaction(function () use ($member, $groupId, $validated, $collectionLogData): void {
             $now = now();
@@ -267,9 +267,9 @@ class GroupMemberController extends Controller
 
     protected function updateCollectionLog(Member $member, array $collectionLogData): void
     {
-        return;
-
-        foreach ($collectionLogData as $itemId => $count) {
+        foreach (array_chunk($collectionLogData, 2) as $entry) {
+            $itemId = $entry[0];
+            $count = $entry[1];
             $member->collectionLogs()->updateOrCreate([
                 'item_id' => $itemId,
             ], [

--- a/resources/components/collection-log/collection-log.tsx
+++ b/resources/components/collection-log/collection-log.tsx
@@ -402,10 +402,6 @@ export const CollectionLogWindow = ({
         </button>
       </div>
       <div className="collection-log-title-border" />
-      <div className="collection-log-warning">
-        Collection log is temporarily unavailable. This will become functional again once the RuneLite plugin update is
-        approved.
-      </div>
       <div className="collection-log-main">
         <div className="collection-log-tab-buttons">{tabButtons}</div>
         <div className="collection-log-tab-container">


### PR DESCRIPTION
<img width="2208" height="1468" alt="image" src="https://github.com/user-attachments/assets/cdac9b6d-619f-417b-a396-3c8b9c9e0cae" />

the group-ironman-tracker plugin networks it as [itemid1,itemcount1, itemid2,itemcount2, ...] with the `collection_log_v2` key. This PR updates the logic accordingly.
```java
        List<Integer> result = new ArrayList<>(clogItems.size() * 2);
        for (Map.Entry<Integer, Integer> item : clogItems.entrySet()) {
            result.add(item.getKey());
            result.add(item.getValue());
        }
        ```