### PR TITLE
Add support for multiple search filters using | as a seperator

### DIFF
--- a/resources/components/items-page/items-page.tsx
+++ b/resources/components/items-page/items-page.tsx
@@ -234,7 +234,16 @@ export const ItemsPage = (): ReactElement => {
   const { totalHighAlch, totalGEPrice, filteredItems } = [...(items ?? [])].reduce<ItemAggregates>(
     (previousValue, [itemID, quantityByMemberName]) => {
       const itemDatum = itemData?.get(itemID);
-      if (!itemDatum?.name.toLocaleLowerCase().includes(searchString)) return previousValue;
+
+      if (itemDatum && searchString.includes("|")) {
+        let success = false;
+        for (const splitSearch of searchString.split("|")) {
+          if (splitSearch.trim().length == 0) continue;
+          success = itemDatum.name.toLocaleLowerCase().includes(splitSearch.trim());
+          if (success) break;
+        }
+        if (!success) return previousValue;
+      } else if (!itemDatum?.name.toLocaleLowerCase().includes(searchString)) return previousValue;
 
       let filteredTotalQuantity = 0;
       quantityByMemberName.forEach((quantity, name) => {
@@ -302,7 +311,7 @@ export const ItemsPage = (): ReactElement => {
     <>
       <div id="items-page-head">
         <SearchElement
-          onChange={(string) => setSearchString(string.toLocaleLowerCase())}
+          onChange={(string) => setSearchString(string.toLocaleLowerCase().trim())}
           id="items-page-search"
           placeholder="Search"
           auto-focus


### PR DESCRIPTION

<img width="1271" height="497" alt="image" src="https://github.com/user-attachments/assets/fda8c29a-420b-470a-8ce7-1baa81d72ccc" />


This was a feature the old site had and was useful for clue scrolls
<img width="3223" height="754" alt="image" src="https://github.com/user-attachments/assets/76f96150-2634-4bf0-afd3-5dfbc8e49ff0" />
